### PR TITLE
Minor fixes for documentation

### DIFF
--- a/client/crud.rst
+++ b/client/crud.rst
@@ -11,7 +11,7 @@ server to store it for us. This is done using ``Create``.
 .. code:: csharp
 
     var pat = new Patient() { /* set up data */ };
-    var created_pat = client.Create(pat);
+    var created_pat = client.Create<Patient>(pat);
 
 .. tip:: See :ref:`FHIR-model` for examples on how to fill a resource with values.
 
@@ -81,7 +81,7 @@ takes the resource instance previously retrieved as a parameter:
 
 	// Add a name to the patient, and update
 	pat_A.Name.Add(new HumanName().WithGiven("Christopher").AndFamily("Brown"));
-	var updated_pat = client.Update(pat_A);
+	var updated_pat = client.Update<Patient>(pat_A);
 
 There's always a chance that between retrieving the resource and sending
 an update, someone else has updated the resource as well. Servers
@@ -195,7 +195,7 @@ call, passing it the resource instance as returned by a previous ``Read``,
 
 .. code:: csharp
 
-	var refreshed_pat = client.Refresh(pat_A);
+	var refreshed_pat = client.Refresh<Patient>(pat_A);
 
 This call will go to the server and fetch the latest version and
 metadata of the resource as pointed to by the ``Id`` property in the

--- a/client/search.rst
+++ b/client/search.rst
@@ -68,20 +68,20 @@ Devices named "foo" as well.
 Complex searches
 ~~~~~~~~~~~~~~~~
 
-An alternative way to specify a query is by creating a ``Query``
-resource and pass this to the client's ``Search(Query q)`` overload. The
-``Query`` resource has a set of fluent calls to allow you to easily
+An alternative way to specify a query is by creating a ``SearchParam``
+resource and pass this to the client's ``Search<TResource>(SearchParam q)`` overload. The
+``SearchParam`` resource has a set of fluent calls to allow you to easily
 construct more complex queries:
 
 .. code:: csharp
 
-  var q = new Query()
- .For("Patient").Where("name:exact=ewout")
- .OrderBy("birthDate", SortOrder.Descending)
- .SummaryOnly().Include("Patient.managingOrganization")
- .LimitTo(20);
+  var q = new SearchParam()
+            .Where("name:exact=ewout")
+            .OrderBy("birthdate", SortOrder.Descending)
+            .SummaryOnly().Include("Patient:organization")
+            .LimitTo(20);
 
- Bundle result = client.Search(q);
+ Bundle result = client.Search<Patient>(q);
 
 Note that unlike the search options shown before, you can specify search
 ordering and the use of a summary result. As well, this syntax avoids


### PR DESCRIPTION
Adding some improvements, and the class `Query` does not exist anymore We have `SearchParams` for that.