### PR TITLE
Correct settings.UseFormatParam to settings.UseFormatParameter

### DIFF
--- a/client/setup.rst
+++ b/client/setup.rst
@@ -62,7 +62,7 @@ latter by default, but if you want, you can use the ``_format`` parameter instea
 
 .. code:: csharp
 
-	client.Settings.UseFormatParam = true;
+	client.Settings.UseFormatParameter = true;
 
 If you perform a ``Create``, ``Update`` or ``Transaction`` interaction, you can request the server
 to either send back the complete representation of the interaction, or a minimal data set, as


### PR DESCRIPTION
I think it's either `client.UseFormatParam` (obsolete) or `client.settings.UseFormatParameter`.
This documentation mixes both.  

I'm just starting out with Firely so I may well be wrong.

Sorry for the whitespace change at the end of the file.  I did this with the GitHub editor.