### PR TITLE
Removed the references to the (de)serialization methods taking an assembly.

### DIFF
--- a/parsing/system-text-json-deserialization.rst
+++ b/parsing/system-text-json-deserialization.rst
@@ -13,13 +13,13 @@ To use it, set up a new ``JsonSerializerOptions`` to add this converter, and the
 .. code-block:: csharp
 
     var jsonInput = "{.....}";
-    var options = new JsonSerializerOptions().ForFhir(typeof(Patient).Assembly);
+    var options = new JsonSerializerOptions().ForFhir(ModelInfo.ModelInspector);
     var patient = JsonSerializer.Deserialize<Patient>(jsonInput, options);
 
-The ``ForFhir()`` method initializes the options to use the FHIR Json converter. This methods has an overload that takes an ``Assembly`` as an argument,
-which is the assembly where the SDK's POCO classes can be found and which will be used to create the resource encountered in the json input text. If you are working
+The ``ForFhir()`` method initializes the options to use the FHIR Json converter. This methods has an overload that takes a ``ModelInspector`` as an argument,
+which is the metadata about where the SDK's POCO classes can be found and which will be used to create the resource encountered in the json input text. If you are working
 with one specific version of FHIR (i.e. you are using a NuGet assembly for R4), there will be an overload
-that does not require the ``Assembly`` argument, and it will default to the version of FHIR you have included in your project.
+that does not require the ``ModelInspector`` argument, and it will default to the version of FHIR you have included in your project.
 
 NB: It is very important that you reuse instances of ``JsonSerializerOptions`` across all your deserialization calls, otherwise performance will degrade tremendously.
 
@@ -30,7 +30,7 @@ When calling `JsonSerializer.Deserialize()`, the SDK will throw a ``Deserializat
 .. code-block:: csharp
 
     string patientString = "{\"resourceType\": \"Patient\",\"id\": \"example-patient\"}";
-    var options = new JsonSerializerOptions().ForFhir(typeof(Patient).Assembly);
+    var options = new JsonSerializerOptions().ForFhir(ModelInfo.ModelInspector);
     try
     {
         Patient p = JsonSerializer.Deserialize<Patient>(patientString, options);

--- a/parsing/system-text-json-serialization.rst
+++ b/parsing/system-text-json-serialization.rst
@@ -11,14 +11,14 @@ To use it, set up a new ``JsonSerializerOptions`` to add this converter, and the
 .. code-block:: csharp
 
     Patient p = new() {  };
-    var options = new JsonSerializerOptions().ForFhir(typeof(Patient).Assembly).Pretty();
+    var options = new JsonSerializerOptions().ForFhir(ModelInfo.ModelInspector).Pretty();
     string patientJson = JsonSerializer.Serialize(p, options);
 
-The ``ForFhir()`` method initializes the options to use the FHIR Json converter. Additionally, we have specified that we want
-indented output. This method has an overload that takes an ``Assembly`` as an argument, which is the assembly where the SDK's POCO classes can be found. This
+The ``ForFhir()`` method initializes the options to use the FHIR Json converter. This methods has an overload that takes a ``ModelInspector`` 
+as an argument, which is the metadata about where the SDK's POCO classes can be found. This
 determines which version of FHIR to use for serialization and is used by deserializer to locate the classes to instantiate when parsing
 FHIR data. If you are working with one specific version of FHIR (i.e. you are using a NuGet assembly for R4), there will be an overload
-that does not require the ``Assembly`` argument, and it will default to the version of FHIR you have included in your project.
+that does not require the ``ModelInspector`` argument, and it will default to the version of FHIR you have included in your project.
 
 NB: It is very important that you reuse instances of ``JsonSerializerOptions`` across all your deserialization calls, otherwise performance will degrade tremendously.
 

--- a/parsing/xml-poco-deserialization.rst
+++ b/parsing/xml-poco-deserialization.rst
@@ -12,10 +12,13 @@ To use it, we first create an ``XmlReader`` and a ``FhirXmlPocoDeserializer`` an
 
     var xml = "<Patient xmlns=\"http://hl7.org/fhir\"> .. </Patient>";
     var xmlReader = XmlReader.Create(new StringReader(xml));
-    var deserializer = new FhirXmlPocoDeserializer(typeof(Patient).Assembly);
+    var deserializer = new FhirXmlPocoDeserializer(ModelInfo.ModelInspector);
     var patient = deserializer.Deserialize<Patient>(xml);
 
-You can see that the ``FhirXmlPocoDeserializer`` takes an ``Assembly`` as an argument, which is the assembly where the SDK's POCO classes can be found and which will be used to create the resource encountered in the xml input text.
+You can see that the ``FhirXmlPocoDeserializer`` takes an takes a ``ModelInspector`` as an argument,
+which is the metadata about where the SDK's POCO classes can be found and which will be used to create the resource encountered in the xml input text. If you are working
+with one specific version of FHIR (i.e. you are using a NuGet assembly for R4), there will be an overload
+that does not require the ``ModelInspector`` argument, and it will default to the version of FHIR you have included in your project.
 
 Finding errors while deserializing
 ----------------------------------
@@ -25,7 +28,7 @@ When calling ``Deserialize()``, the SDK will throw a ``DeserializationFailedExce
 
     var xml = "<Patient xmlns=\"http://hl7.org/fhir\"> .. </patient>";
     var xmlReader = XmlReader.Create(new StringReader(xml));
-    var deserializer = new FhirXmlPocoDeserializer(typeof(Patient).Assembly);
+    var deserializer = new FhirXmlPocoDeserializer(ModelInfo.ModelInspector);
   
     try
     {


### PR DESCRIPTION
We prefer using ModelInspector now.